### PR TITLE
Provide assertions ivar for Minitest.

### DIFF
--- a/spec/rspec/active_model/mocks/mock_model_spec.rb
+++ b/spec/rspec/active_model/mocks/mock_model_spec.rb
@@ -385,6 +385,7 @@ describe "mock_model(RealModel)" do
     begin
       require 'minitest/assertions'
       include Minitest::Assertions
+      include MinitestAssertion
     rescue LoadError
       require 'test/unit/assertions'
       include Test::Unit::Assertions

--- a/spec/support/minitest_support.rb
+++ b/spec/support/minitest_support.rb
@@ -1,0 +1,12 @@
+# Minitest requires you provide an assertions ivar for the context
+# it is running within. We need this so that ActiveModel::Lint tests
+# can successfully be run.
+module MinitestAssertion
+  def assertions
+    @assertions ||= 0
+  end
+
+  def assertions=(value)
+    @assertions = value
+  end
+end


### PR DESCRIPTION
Minitest requires an assertion var be available to increment inside
the class that it is running. Add a module that can be mixed in that
provides the methods required.

See https://github.com/seattlerb/minitest/commit/714cd8a7e0e9d319c6bf45cfedd0910f381b267b
