### PR TITLE
Supports `has_attribute?` on mock_model doubles

### DIFF
--- a/lib/rspec/active_model/mocks/mocks.rb
+++ b/lib/rspec/active_model/mocks/mocks.rb
@@ -146,6 +146,10 @@ EOM
           model_class.respond_to?(:column_names) && model_class.column_names.include?(method_name.to_s)
         end
 
+        msingleton.__send__(:define_method, :has_attribute?) do |attr_name|
+          __model_class_has_column?(attr_name)
+        end unless stubs.has_key?(:has_attribute?)
+
         msingleton.__send__(:define_method, :respond_to?) do |method_name, *args|
         include_private = args.first || false
           __model_class_has_column?(method_name) ? true : super(method_name, include_private)

--- a/spec/rspec/active_model/mocks/mock_model_spec.rb
+++ b/spec/rspec/active_model/mocks/mock_model_spec.rb
@@ -193,6 +193,33 @@ describe "mock_model(RealModel)" do
     end
   end
 
+  describe "#has_attribute?" do
+    context "with an ActiveRecord model" do
+      before(:each) do
+        MockableModel.stub(:column_names).and_return(["column_a", "column_b"])
+        @model = mock_model(MockableModel)
+      end
+
+      it "has a given attribute if the underlying model has column of the same name" do
+        expect(@model.has_attribute?("column_a")).to be_truthy
+        expect(@model.has_attribute?("column_b")).to be_truthy
+        expect(@model.has_attribute?("column_c")).to be_falsey
+      end
+
+      it "accepts symbols" do
+        expect(@model.has_attribute?(:column_a)).to be_truthy
+        expect(@model.has_attribute?(:column_b)).to be_truthy
+        expect(@model.has_attribute?(:column_c)).to be_falsey
+      end
+
+      it "allows has_attribute? to be explicitly stubbed" do
+        @model = mock_model(MockableModel, :has_attribute? => false)
+        expect(@model.has_attribute?(:column_a)).to be_falsey
+        expect(@model.has_attribute?(:column_b)).to be_falsey
+      end
+    end
+  end
+
   describe "#respond_to?" do
     context "with an ActiveRecord model" do
       before(:each) do


### PR DESCRIPTION
Forward port of rspec/rspec-rails#965
