### PR TITLE
Fix mocking belongs_to associations in Rails 4.2+

### DIFF
--- a/lib/rspec/active_model/mocks/mocks.rb
+++ b/lib/rspec/active_model/mocks/mocks.rb
@@ -52,6 +52,10 @@ module RSpec::ActiveModel::Mocks
         send(key)
       end
 
+      # Rails>4.2 uses _read_attribute internally, as an optimized
+      # alternative to record['id']
+      alias_method :_read_attribute, :[]
+
       # Returns the opposite of `persisted?`
       def new_record?
         !persisted?


### PR DESCRIPTION
Hi there - if you test rspec-activemodel-mocks against Rails' 4-2-stable branch, or against master, you'll get failures when mocking belongs_to assocations : 

```
  4) mock_model(RealModel) as association that doesn't exist yet passes: associated_model == mock
     Failure/Error: @real.nonexistent_model = @mock_model
       Double "Other_1096" received unexpected message :_read_attribute with (:id)
     # /Users/jon/.rvm/gems/ruby-2.1.2/bundler/gems/rails-5383f22bb83a/activerecord/lib/active_record/associations/belongs_to_association.rb:80:in `replace_keys'
     # /Users/jon/.rvm/gems/ruby-2.1.2/bundler/gems/rails-5383f22bb83a/activerecord/lib/active_record/associations/belongs_to_association.rb:14:in `replace'
     # /Users/jon/.rvm/gems/ruby-2.1.2/bundler/gems/rails-5383f22bb83a/activerecord/lib/active_record/associations/singular_association.rb:17:in `writer'
     # /Users/jon/.rvm/gems/ruby-2.1.2/bundler/gems/rails-5383f22bb83a/activerecord/lib/active_record/associations/builder/association.rb:123:in `nonexistent_model='
     # ./spec/rspec/active_model/mocks/mock_model_spec.rb:130:in `block (3 levels) in <top (required)>'
```

Rails has recently added a `_read_attribute` method, which it uses internally instead of `[]`.  How about the attached PR?