### PR TITLE
Support for stubbing database view backed models

### DIFF
--- a/lib/rspec/active_model/mocks/mocks.rb
+++ b/lib/rspec/active_model/mocks/mocks.rb
@@ -238,7 +238,7 @@ EOM
     def stub_model(model_class, stubs={})
       model_class.new.tap do |m|
         m.extend ActiveModelStubExtensions
-        if defined?(ActiveRecord) && model_class < ActiveRecord::Base
+        if defined?(ActiveRecord) && model_class < ActiveRecord::Base && model_class.primary_key
           m.extend ActiveRecordStubExtensions
           primary_key = model_class.primary_key.to_sym
           stubs = {primary_key => next_id}.merge(stubs)

--- a/spec/rspec/active_model/mocks/stub_model_spec.rb
+++ b/spec/rspec/active_model/mocks/stub_model_spec.rb
@@ -151,4 +151,16 @@ describe "stub_model" do
     end
 
   end
+
+  context "with an ActiveRecord model with no primary key" do
+    let(:model_class) { MockableModelNoPrimaryKey }
+
+    it "yields the model" do
+      model = stub_model(model_class) do |block_arg|
+        @block_arg = block_arg
+      end
+      expect(model).to be(@block_arg)
+    end
+
+  end
 end

--- a/spec/support/ar_classes.rb
+++ b/spec/support/ar_classes.rb
@@ -16,6 +16,23 @@ module Connections
   end
 end
 
+module ConnectionsView
+  def self.extended(host)
+    host.connection.execute <<-eosql
+      CREATE TABLE some_table (
+        associated_model_id integer,
+        mockable_model_id integer,
+        nonexistent_model_id integer
+      )
+    eosql
+
+    host.connection.execute <<-eosql
+      CREATE VIEW #{host.table_name} AS
+        select * from some_table;
+    eosql
+  end
+end
+
 class NonActiveRecordModel
   extend ActiveModel::Naming
   include ActiveModel::Conversion
@@ -24,6 +41,11 @@ end
 class MockableModel < ActiveRecord::Base
   extend Connections
   has_one :associated_model
+end
+
+# (e.g. model backed database views)
+class MockableModelNoPrimaryKey < ActiveRecord::Base
+  extend ConnectionsView
 end
 
 class SubMockableModel < MockableModel


### PR DESCRIPTION
a model that is backed by database view won't have a primary key.