### PR TITLE
Removed deprecated option from .gemspec

### DIFF
--- a/rspec-activemodel-mocks.gemspec
+++ b/rspec-activemodel-mocks.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |s|
   s.summary     = "rspec-activemodel-mocks-#{RSpec::ActiveModel::Mocks::Version::STRING}"
   s.description = "RSpec test doubles for ActiveModel and ActiveRecord"
 
-  s.rubyforge_project = "rspec"
-
   s.files             = `git ls-files -- lib/*`.split("\n")
   s.files            += %w[README.md License.txt .yardopts]
   s.test_files        = `git ls-files -- {spec,features}/*`.split("\n")


### PR DESCRIPTION
This PR is related to https://github.com/rspec/rspec-core/pull/1974
Thank you. 