### PR TITLE
Read attribute problem corrected, and travis.yml updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,10 @@ matrix:
   exclude:
     # Rails 3.x - 4.0 do not support ruby 2.2.2:
     - rvm: 2.2.2
-      env:
-        - RAILS_VERSION=3.1-stable
-        - RAILS_VERSION=3.2-stable
-        - RAILS_VERSION=4.0-stable
+      env: RAILS_VERSION=3.1-stable
+    - rvm: 2.2.2
+      env: RAILS_VERSION=3.2-stable
+    - rvm: 2.2.2
+      env: RAILS_VERSION=4.0-stable
   allow_failures:
     - env: RAILS_VERSION=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,39 +5,17 @@ before_install:
   - gem --version
   - gem install bundler
 rvm:
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.2.2
 env:
   - RAILS_VERSION=master
+  - RAILS_VERSION=4-2-stable
+  - RAILS_VERSION=4-1-stable
   - RAILS_VERSION=4-0-stable
-  - RAILS_VERSION=4.0.2
   - RAILS_VERSION=3-2-stable
-  - RAILS_VERSION=3.2.16
-  - RAILS_VERSION=3.1.12
-  - RAILS_VERSION=3.0.20
+  - RAILS_VERSION=3-1-stable
 matrix:
-  exclude:
-    # 3.0.x is not supported on MRI 2.0.0
-    - rvm: 2.0.0
-      env: RAILS_VERSION=3.0.20
-    # 3.0.x is not supported on MRI 2.1.0
-    - rvm: 2.1.0
-      env: RAILS_VERSION=3.0.20
-    # 4.0.x is not supported on MRI 1.8.7 or 1.9.2
-    - rvm: 1.8.7
-      env: RAILS_VERSION=master
-    - rvm: 1.9.2
-      env: RAILS_VERSION=master
-    - rvm: 1.8.7
-      env: RAILS_VERSION=4-0-stable
-    - rvm: 1.9.2
-      env: RAILS_VERSION=4-0-stable
-    - rvm: 1.8.7
-      env: RAILS_VERSION=4.0.2
-    - rvm: 1.9.2
-      env: RAILS_VERSION=4.0.2
   allow_failures:
     - env: RAILS_VERSION=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,12 @@ env:
   - RAILS_VERSION=3-2-stable
   - RAILS_VERSION=3-1-stable
 matrix:
+  exclude:
+    # Rails 3.x - 4.0 do not support ruby 2.2.2:
+    - rvm: 2.2.2
+      env:
+        - RAILS_VERSION=3.1-stable
+        - RAILS_VERSION=3.2-stable
+        - RAILS_VERSION=4.0-stable
   allow_failures:
     - env: RAILS_VERSION=master

--- a/lib/rspec/active_model/mocks/mocks.rb
+++ b/lib/rspec/active_model/mocks/mocks.rb
@@ -52,6 +52,10 @@ module RSpec::ActiveModel::Mocks
         send(key)
       end
 
+      # Rails>4.2 uses _read_attribute internally, as an optimized
+      # alternative to record['id']
+      alias_method :_read_attribute, :[]
+
       # Returns the opposite of `persisted?`
       def new_record?
         !persisted?


### PR DESCRIPTION
The code change here is the same as pull request #10.

The travis builds fail in that pull request because since the last version of rspec-activemodel-mocks was released, the i18n gem has bumped to 0.7.0. However, this version of i18n requires Ruby >= 1.9.3.

Basically, in order to support Rails 4.x (which requires i18n ~> 0.7), this gem can no longer support Ruby < 1.9.3 in new versions going forward, and should no longer attempt to build those targets in Travis.