### PR TITLE
Read attribute problem corrected, and travis.yml updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,10 @@ matrix:
   exclude:
     # Rails 3.x - 4.0 do not support ruby 2.2.2:
     - rvm: 2.2.2
-      env:
-        - RAILS_VERSION=3.1-stable
-        - RAILS_VERSION=3.2-stable
-        - RAILS_VERSION=4.0-stable
+      env: RAILS_VERSION=3.1-stable
+    - rvm: 2.2.2
+      env: RAILS_VERSION=3.2-stable
+    - rvm: 2.2.2
+      env: RAILS_VERSION=4.0-stable
   allow_failures:
     - env: RAILS_VERSION=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ before_install:
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.0
-  - 2.2.2
+  - 2.1.7
+  - 2.2.3
 env:
   - RAILS_VERSION=master
   - RAILS_VERSION=4-2-stable
@@ -18,12 +18,12 @@ env:
   - RAILS_VERSION=3-1-stable
 matrix:
   exclude:
-    # Rails 3.x - 4.0 do not support ruby 2.2.2:
-    - rvm: 2.2.2
-      env: RAILS_VERSION=3.1-stable
-    - rvm: 2.2.2
-      env: RAILS_VERSION=3.2-stable
-    - rvm: 2.2.2
-      env: RAILS_VERSION=4.0-stable
+    # Rails 3.x - 4.0 do not support ruby 2.2.x
+    - rvm: 2.2.3
+      env: RAILS_VERSION=3-1-stable
+    - rvm: 2.2.3
+      env: RAILS_VERSION=3-2-stable
+    - rvm: 2.2.3
+      env: RAILS_VERSION=4-0-stable
   allow_failures:
     - env: RAILS_VERSION=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,39 +5,17 @@ before_install:
   - gem --version
   - gem install bundler
 rvm:
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.2.2
 env:
   - RAILS_VERSION=master
+  - RAILS_VERSION=4-2-stable
+  - RAILS_VERSION=4-1-stable
   - RAILS_VERSION=4-0-stable
-  - RAILS_VERSION=4.0.2
   - RAILS_VERSION=3-2-stable
-  - RAILS_VERSION=3.2.16
-  - RAILS_VERSION=3.1.12
-  - RAILS_VERSION=3.0.20
+  - RAILS_VERSION=3-1-stable
 matrix:
-  exclude:
-    # 3.0.x is not supported on MRI 2.0.0
-    - rvm: 2.0.0
-      env: RAILS_VERSION=3.0.20
-    # 3.0.x is not supported on MRI 2.1.0
-    - rvm: 2.1.0
-      env: RAILS_VERSION=3.0.20
-    # 4.0.x is not supported on MRI 1.8.7 or 1.9.2
-    - rvm: 1.8.7
-      env: RAILS_VERSION=master
-    - rvm: 1.9.2
-      env: RAILS_VERSION=master
-    - rvm: 1.8.7
-      env: RAILS_VERSION=4-0-stable
-    - rvm: 1.9.2
-      env: RAILS_VERSION=4-0-stable
-    - rvm: 1.8.7
-      env: RAILS_VERSION=4.0.2
-    - rvm: 1.9.2
-      env: RAILS_VERSION=4.0.2
   allow_failures:
     - env: RAILS_VERSION=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,12 @@ env:
   - RAILS_VERSION=3-2-stable
   - RAILS_VERSION=3-1-stable
 matrix:
+  exclude:
+    # Rails 3.x - 4.0 do not support ruby 2.2.2:
+    - rvm: 2.2.2
+      env:
+        - RAILS_VERSION=3.1-stable
+        - RAILS_VERSION=3.2-stable
+        - RAILS_VERSION=4.0-stable
   allow_failures:
     - env: RAILS_VERSION=master

--- a/lib/rspec/active_model/mocks/mocks.rb
+++ b/lib/rspec/active_model/mocks/mocks.rb
@@ -52,6 +52,10 @@ module RSpec::ActiveModel::Mocks
         send(key)
       end
 
+      # Rails>4.2 uses _read_attribute internally, as an optimized
+      # alternative to record['id']
+      alias_method :_read_attribute, :[]
+
       # Returns the opposite of `persisted?`
       def new_record?
         !persisted?


### PR DESCRIPTION
Based entirely on prior work done by @corporealfunk in https://github.com/rspec/rspec-activemodel-mocks/pull/15 and @jdelStrother in https://github.com/rspec/rspec-activemodel-mocks/pull/10

This PR attempts to resolve the failing builds in travis.

* Rails 3.x to 4.0.x are now excluded when using Ruby 2.2.x as they do not support Ruby 2.2.x.
* In order to support Rails 4.x, the minimum version of Ruby supported should be 1.9.3

Fixes #11 
