### PR TITLE
Fix mocking belongs_to associations in Rails 4.2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,23 @@ rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
-  - 2.0.0
-  - 2.1.0
+  - 2.0
+  - 2.1
+  - 2.2
 env:
   - RAILS_VERSION=master
+  - RAILS_VERSION=4-2-stable
+  - RAILS_VERSION=4-1-stable
   - RAILS_VERSION=4-0-stable
-  - RAILS_VERSION=4.0.2
   - RAILS_VERSION=3-2-stable
   - RAILS_VERSION=3.2.16
   - RAILS_VERSION=3.1.12
   - RAILS_VERSION=3.0.20
 matrix:
   exclude:
+    # MRI 2.2 is not supported on a few versions
+    - rvm: 2.2
+      env: RAILS_VERSION='~> 3.1.12'
     # 3.0.x is not supported on MRI 2.0.0
     - rvm: 2.0.0
       env: RAILS_VERSION=3.0.20
@@ -32,7 +37,15 @@ matrix:
     - rvm: 1.9.2
       env: RAILS_VERSION=master
     - rvm: 1.8.7
+      env: RAILS_VERSION=4-2-stable
+    - rvm: 1.8.7
+      env: RAILS_VERSION=4-1-stable
+    - rvm: 1.8.7
       env: RAILS_VERSION=4-0-stable
+    - rvm: 1.9.2
+      env: RAILS_VERSION=4-2-stable
+    - rvm: 1.9.2
+      env: RAILS_VERSION=4-1-stable
     - rvm: 1.9.2
       env: RAILS_VERSION=4-0-stable
     - rvm: 1.8.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 script: "bin/rake --trace 2>&1"
 bundler_args: "--binstubs --without documentation"
 before_install:
-  - gem update --system 2.1.11
+  - gem update --system
   - gem --version
   - gem install bundler
 rvm:
@@ -55,3 +55,8 @@ matrix:
       env: RAILS_VERSION=4.0.2
   allow_failures:
     - env: RAILS_VERSION=master
+
+branches:
+  only:
+    - master
+    - /^\d+-\d+-maintenance$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,15 @@ env:
   - RAILS_VERSION=4-1-stable
   - RAILS_VERSION=4-0-stable
   - RAILS_VERSION=3-2-stable
-  - RAILS_VERSION=3.2.16
   - RAILS_VERSION=3.1.12
   - RAILS_VERSION=3.0.20
 matrix:
   exclude:
     # MRI 2.2 is not supported on a few versions
     - rvm: 2.2
-      env: RAILS_VERSION='~> 3.1.12'
+      env: RAILS_VERSION=3.1.12
+    - rvm: 2.2
+      env: RAILS_VERSION=3.0.20
     # 3.0.x is not supported on MRI 2.0.0
     - rvm: 2.0.0
       env: RAILS_VERSION=3.0.20

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 script: "bin/rake --trace 2>&1"
+sudo: false
 bundler_args: "--binstubs --without documentation"
 before_install:
   - gem update --system

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :documentation do
   gem 'github-markup', '1.0.0'
 end
 
-case version = ENV.fetch('RAILS_VERSION', '4.0.2')
+case version = ENV.fetch('RAILS_VERSION', '4.2.4')
 when /\Amaster\z/, /stable\z/
   gem "activerecord", :github => "rails/rails", :branch => version
   gem "activemodel", :github => "rails/rails", :branch => version
@@ -30,5 +30,7 @@ else
   gem "activemodel", version
   gem "activesupport", version
 end
+
+gem "test-unit", '~> 3' if version >= '3.2.22' && version < '4.0.0'
 
 gem "i18n", '< 0.7.0' if RUBY_VERSION < '1.9.3'

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,6 @@ else
   gem "activesupport", version
 end
 
-gem "test-unit", '~> 3' if version >= '3.2.22' && version < '4.0.0'
+gem "test-unit", '~> 3' if (version >= '3.2.22' || version == '3-2-stable') && version < '4.0.0'
 
 gem "i18n", '< 0.7.0' if RUBY_VERSION < '1.9.3'

--- a/lib/rspec/active_model/mocks/mocks.rb
+++ b/lib/rspec/active_model/mocks/mocks.rb
@@ -52,6 +52,10 @@ module RSpec::ActiveModel::Mocks
         send(key)
       end
 
+      # Rails>4.2 uses _read_attribute internally, as an optimized
+      # alternative to record['id']
+      alias_method :_read_attribute, :[]
+
       # Returns the opposite of `persisted?`
       def new_record?
         !persisted?

--- a/spec/rspec/active_model/mocks/mock_model_spec.rb
+++ b/spec/rspec/active_model/mocks/mock_model_spec.rb
@@ -424,7 +424,7 @@ describe "mock_model(RealModel)" do
           gem 'minitest' if defined?(Kernel.gem)
           require 'minitest/unit'
           include MiniTest::Assertions
-        elsif version >= '3.2.22'
+        elsif version >= '3.2.22' || version == '3-2-stable'
           begin
             # Test::Unit "helpfully" sets up autoload for its `AutoRunner`.
             # While we do not reference it directly, when we load the `TestCase`

--- a/spec/rspec/active_model/mocks/mock_model_spec.rb
+++ b/spec/rspec/active_model/mocks/mock_model_spec.rb
@@ -423,7 +423,7 @@ describe "mock_model(RealModel)" do
           # This gem has no `lib/minitest.rb` file.
           gem 'minitest' if defined?(Kernel.gem)
           require 'minitest/unit'
-          Assertions = MiniTest::Assertions
+          include MiniTest::Assertions
         elsif version >= '3.2.22'
           begin
             # Test::Unit "helpfully" sets up autoload for its `AutoRunner`.
@@ -443,7 +443,7 @@ describe "mock_model(RealModel)" do
               Gemfile: `gem 'test-unit', '~> 3.0'` (#{e.message})"
             ERR
           end
-          Assertions = Test::Unit::Assertions
+          include Test::Unit::Assertions
         else
           raise LoadError, <<-ERR.squeeze
             Ruby 2.2+ doesn't support this version of Rails #{version}

--- a/spec/rspec/active_model/mocks/mock_model_spec.rb
+++ b/spec/rspec/active_model/mocks/mock_model_spec.rb
@@ -444,6 +444,11 @@ describe "mock_model(RealModel)" do
             ERR
           end
           include Test::Unit::Assertions
+          if defined?(Test::Unit::AutoRunner.need_auto_run = ())
+            Test::Unit::AutoRunner.need_auto_run = false
+          elsif defined?(Test::Unit.run = ())
+            Test::Unit.run = false
+          end
         else
           raise LoadError, <<-ERR.squeeze
             Ruby 2.2+ doesn't support this version of Rails #{version}
@@ -452,6 +457,11 @@ describe "mock_model(RealModel)" do
       else
         require 'test/unit/assertions'
         include Test::Unit::Assertions
+        if defined?(Test::Unit::AutoRunner.need_auto_run = ())
+          Test::Unit::AutoRunner.need_auto_run = false
+        elsif defined?(Test::Unit.run = ())
+          Test::Unit.run = false
+        end
       end
     end
 

--- a/spec/rspec/active_model/mocks/mock_model_spec.rb
+++ b/spec/rspec/active_model/mocks/mock_model_spec.rb
@@ -414,8 +414,45 @@ describe "mock_model(RealModel)" do
       include Minitest::Assertions
       include MinitestAssertion
     rescue LoadError
-      require 'test/unit/assertions'
-      include Test::Unit::Assertions
+      if RUBY_VERSION >= '2.2.0'
+        # Minitest / TestUnit has been removed from ruby core. However, we are
+        # on an old Rails version and must load the appropriate gem
+        version = ENV.fetch('RAILS_VERSION', '4.2.4')
+        if version >= '4.0.0'
+          # ActiveSupport 4.0.x has the minitest '~> 4.2' gem as a dependency
+          # This gem has no `lib/minitest.rb` file.
+          gem 'minitest' if defined?(Kernel.gem)
+          require 'minitest/unit'
+          Assertions = MiniTest::Assertions
+        elsif version >= '3.2.22'
+          begin
+            # Test::Unit "helpfully" sets up autoload for its `AutoRunner`.
+            # While we do not reference it directly, when we load the `TestCase`
+            # classes from AS (ActiveSupport), AS kindly references `AutoRunner`
+            # for everyone.
+            #
+            # To handle this we need to pre-emptively load 'test/unit' and make
+            # sure the version installed has `AutoRunner` (the 3.x line does to
+            # date). If so, we turn the auto runner off.
+            require 'test/unit'
+            require 'test/unit/assertions'
+          rescue LoadError => e
+            raise LoadError, <<-ERR.squeeze, e.backtrace
+              Ruby 2.2+ has removed test/unit from the core library. Rails
+              requires this as a dependency. Please add test-unit gem to your
+              Gemfile: `gem 'test-unit', '~> 3.0'` (#{e.message})"
+            ERR
+          end
+          Assertions = Test::Unit::Assertions
+        else
+          raise LoadError, <<-ERR.squeeze
+            Ruby 2.2+ doesn't support this version of Rails #{version}
+          ERR
+        end
+      else
+        require 'test/unit/assertions'
+        include Test::Unit::Assertions
+      end
     end
 
     require 'active_model/lint'


### PR DESCRIPTION
This #10 #11 #15 #19 updated for newer versions of ruby/rails.

Fixes #10 #11 #15 #19