### PR TITLE
Fix use of deprecated 'stub'

### DIFF
--- a/spec/rspec/active_model/mocks/mock_model_spec.rb
+++ b/spec/rspec/active_model/mocks/mock_model_spec.rb
@@ -196,7 +196,7 @@ describe "mock_model(RealModel)" do
   describe "#has_attribute?" do
     context "with an ActiveRecord model" do
       before(:each) do
-        MockableModel.stub(:column_names).and_return(["column_a", "column_b"])
+        allow(MockableModel).to receive(:column_names).and_return(["column_a", "column_b"])
         @model = mock_model(MockableModel)
       end
 


### PR DESCRIPTION
Fixes:

> Using `stub` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /Users/jason/rspec-activemodel-mocks/spec/rspec/active_model/mocks/mock_model_spec.rb:199:in `block (4 levels) in <top (required)>'.