### PR TITLE
Fix Rails 5.2.1 compatibility for this commit in ActiveRecord 5.2.1: …

### DIFF
--- a/lib/rspec/active_model/mocks/mocks.rb
+++ b/lib/rspec/active_model/mocks/mocks.rb
@@ -38,6 +38,11 @@ module RSpec::ActiveModel::Mocks
       def initialize(association_name)
         @association_name = association_name
       end
+
+      def inversed_from(record)
+        self.target = record
+        @inversed = !!record
+      end
     end
 
     module ActiveRecordInstanceMethods


### PR DESCRIPTION
Due to this commit in ActiveRecord 5.2.1: https://github.com/rails/rails/commit/6edf354b656ec556c3573402019504a519531953#diff-c47e1c26ae8a3d486119e0cc91f40a30

you will get a undefined_method error for the method inversed_from, when assigning an association of a mock. Adding this method to the mock class resolves this problem.