### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/rspec-activemodel-mocks.gemspec
+++ b/rspec-activemodel-mocks.gemspec
@@ -13,6 +13,13 @@ Gem::Specification.new do |s|
   s.summary     = "rspec-activemodel-mocks-#{RSpec::ActiveModel::Mocks::Version::STRING}"
   s.description = "RSpec test doubles for ActiveModel and ActiveRecord"
 
+  s.metadata = {
+    'bug_tracker_uri'   => 'https://github.com/rspec/rspec-activemodel-mocks/issues',
+    'documentation_uri' => 'https://rspec.info/documentation/',
+    'mailing_list_uri'  => 'https://groups.google.com/forum/#!forum/rspec',
+    'source_code_uri'   => 'https://github.com/rspec/rspec-activemodel-mocks',
+  }
+
   s.files             = `git ls-files -- lib/*`.split("\n")
   s.files            += %w[README.md License.txt .yardopts]
   s.test_files        = `git ls-files -- {spec,features}/*`.split("\n")


### PR DESCRIPTION
Following on from rspec/rspec-core#2574.

Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the documentation. These `bug_tracker_uri`, `documentation_uri`, `mailing_list_uri` and `source_code_uri` links will appear or replace those on the rubygems page at https://rubygems.org/gems/rspec-activemodel-mocks after the next release.