### PR TITLE
CI: Drop unused setting, update build matrix, resolve version-specific depdendencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ before_install:
   - gem --version
 matrix:
   include:
-    # Rails dev / 6 builds >= 2.4.5
+    # Rails dev / 6 builds >= 2.5.0
     - rvm: 2.5.3
-      env: RAILS_VERSION=master
-    - rvm: 2.4.5
       env: RAILS_VERSION=master
 
     # Rails 5.2 builds >= 2.2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,15 @@ before_install:
 matrix:
   include:
     # Rails dev / 6 builds >= 2.5.0
-    - rvm: 2.5.3
+    - rvm: 2.6.2
+      env: RAILS_VERSION=master
+    - rvm: 2.5.5
       env: RAILS_VERSION=master
 
     # Rails 5.2 builds >= 2.2.2
-    - rvm: 2.5.3
+    - rvm: 2.5.5
       env: RAILS_VERSION='~> 5.2.0'
-    - rvm: 2.4.5
+    - rvm: 2.4.6
       env: RAILS_VERSION='~> 5.2.0'
     - rvm: 2.3.8
       env: RAILS_VERSION='~> 5.2.0'
@@ -20,9 +22,9 @@ matrix:
       env: RAILS_VERSION='~> 5.2.0'
 
     # Rails 5.1 Builds >= 2.2.2
-    - rvm: 2.5.3
+    - rvm: 2.5.5
       env: RAILS_VERSION='~> 5.1.0'
-    - rvm: 2.4.5
+    - rvm: 2.4.6
       env: RAILS_VERSION='~> 5.1.0'
     - rvm: 2.3.8
       env: RAILS_VERSION='~> 5.1.0'
@@ -30,9 +32,9 @@ matrix:
       env: RAILS_VERSION='~> 5.1.0'
 
     # Rails 5.0 Builds >= 2.2.2
-    - rvm: 2.5.3
+    - rvm: 2.5.5
       env: RAILS_VERSION='~> 5.0.0'
-    - rvm: 2.4.5
+    - rvm: 2.4.6
       env: RAILS_VERSION='~> 5.0.0'
     - rvm: 2.3.8
       env: RAILS_VERSION='~> 5.0.0'
@@ -40,9 +42,9 @@ matrix:
       env: RAILS_VERSION='~> 5.0.0'
 
     # Rails 4.2 Builds >= 1.9.3
-    - rvm: 2.4.5
+    - rvm: 2.4.6
       env: RAILS_VERSION='~> 4.2.0'
-    - rvm: 2.4.5
+    - rvm: 2.4.6
       env: RAILS_VERSION=4-2-stable
     - rvm: 2.3.8
       env: RAILS_VERSION='~> 4.2.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 script: "bin/rake --trace 2>&1"
-sudo: false
 bundler_args: "--binstubs --without documentation"
 before_install:
   - script/update_rubygems_and_install_bundler

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ when /\Amaster\z/, /stable\z/
   gem "activerecord", :github => "rails/rails", :branch => version
   gem "activemodel", :github => "rails/rails", :branch => version
   gem "activesupport", :github => "rails/rails", :branch => version
-  if version.start_with?('4-') || version.start_with?('~> 4')
+  if version.start_with?('4-') || version.start_with?('~> 4') || version.start_with?('4')
     gem 'sqlite3', '~> 1.3.6'
   else
     gem 'sqlite3'

--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,10 @@ when /\Amaster\z/, /stable\z/
   gem "activerecord", :github => "rails/rails", :branch => version
   gem "activemodel", :github => "rails/rails", :branch => version
   gem "activesupport", :github => "rails/rails", :branch => version
-  if version.start_with?('4-') || version.start_with?('~> 4') || version.start_with?('4')
+  if version.start_with?('~> 4') || version.start_with?('4')
     gem 'sqlite3', '~> 1.3.6'
+  elsif version.start_with?('~> 3') || version.start_with?('3')
+    gem 'sqlite3', '~> 1.3.5'
   else
     gem 'sqlite3'
   end

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gemspec
   end
 end
 
-gem 'sqlite3'
 
 ### deps for rdoc.info
 group :documentation do
@@ -25,11 +24,15 @@ when /\Amaster\z/, /stable\z/
   gem "activerecord", :github => "rails/rails", :branch => version
   gem "activemodel", :github => "rails/rails", :branch => version
   gem "activesupport", :github => "rails/rails", :branch => version
+  gem 'sqlite3'
 else
   gem "activerecord", version
   gem "activemodel", version
   gem "activesupport", version
+  gem 'sqlite3', '~> 1.3.6'
 end
+
+
 
 if version < '4.0.0'
   gem "test-unit", '~> 3' if (version >= '3.2.22' || version == '3-2-stable')

--- a/Gemfile
+++ b/Gemfile
@@ -38,8 +38,6 @@ else
   gem 'sqlite3', '~> 1.3.6'
 end
 
-
-
 if version < '4.0.0'
   gem "test-unit", '~> 3' if (version >= '3.2.22' || version == '3-2-stable')
 else

--- a/Gemfile
+++ b/Gemfile
@@ -24,9 +24,9 @@ when /\Amaster\z/, /stable\z/
   gem "activerecord", :github => "rails/rails", :branch => version
   gem "activemodel", :github => "rails/rails", :branch => version
   gem "activesupport", :github => "rails/rails", :branch => version
-  if version.start_with?('~> 4') || version.start_with?('4')
+  if version.start_with?('4')
     gem 'sqlite3', '~> 1.3.6'
-  elsif version.start_with?('~> 3') || version.start_with?('3')
+  elsif version.start_with?('3')
     gem 'sqlite3', '~> 1.3.5'
   else
     gem 'sqlite3'

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,11 @@ when /\Amaster\z/, /stable\z/
   gem "activerecord", :github => "rails/rails", :branch => version
   gem "activemodel", :github => "rails/rails", :branch => version
   gem "activesupport", :github => "rails/rails", :branch => version
-  gem 'sqlite3'
+  if version.start_with?('4-') || version.start_with?('~> 4')
+    gem 'sqlite3', '~> 1.3.6'
+  else
+    gem 'sqlite3'
+  end
 else
   gem "activerecord", version
   gem "activemodel", version

--- a/rspec-activemodel-mocks.gemspec
+++ b/rspec-activemodel-mocks.gemspec
@@ -39,6 +39,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake',     '~> 10.0.0'
   s.add_development_dependency 'cucumber', '~> 1.3'
   s.add_development_dependency 'aruba',    '~> 0.4.11'
-  s.add_development_dependency 'ZenTest',  '~> 4.9.5'
+  s.add_development_dependency 'ZenTest',  '~> 4.11.1'
   s.add_development_dependency(%q<activerecord>,  [">= 3.0"])
 end

--- a/rspec-activemodel-mocks.gemspec
+++ b/rspec-activemodel-mocks.gemspec
@@ -39,6 +39,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake',     '~> 10.0.0'
   s.add_development_dependency 'cucumber', '~> 1.3'
   s.add_development_dependency 'aruba',    '~> 0.4.11'
-  s.add_development_dependency 'ZenTest',  '~> 4.11.1'
+  s.add_development_dependency 'ZenTest',  '~> 4.11.2'
   s.add_development_dependency(%q<activerecord>,  [">= 3.0"])
 end


### PR DESCRIPTION
This PR updates the CI matrix:

  - Updates Ruby patch versions in matrix to **2.4.6**, **2.5.5**
  - Adds **Ruby 2.6.2** for **Rails 6**
  - Removes `sudo: false`, an old Travis setting. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
---

# Build failures

Issues dealt with:

- [x] Update **ZenTest** to a newer version compatible with RubyGems 3.0.0+
- [x] Use Ruby 2.5+ with **Rails 6**
- [x] [**Rails 5.0.7.2, Ruby 2.3**](https://travis-ci.org/rspec/rspec-activemodel-mocks/jobs/520742649#L700): `Gem::LoadError:  can't activate sqlite3 (~> 1.3.6), already activated sqlite3-1.4.0. Make sure all dependencies are added to Gemfile.`
- [x] [**Rails 4.2.11.1, Ruby 2.4**](https://travis-ci.org/rspec/rspec-activemodel-mocks/jobs/520742659#L688): Same.
- [x] **Rails 3**: Same, for `sqlite ~> 1.3.5`

The build failures about `sqlite3` are explained in [this StackOverflow thread](https://stackoverflow.com/a/54729071/267348).

