### PR TITLE
6.1 associations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,15 @@ before_install:
   - gem --version
 matrix:
   include:
-    # Rails dev / 6 builds >= 2.4.10
+    # Rails 6.1 builds >= 2.4.10
+    - rvm: 2.7.1
+      env: RAILS_VERSION='~> 6.1.0'
+    - rvm: 2.6.6
+      env: RAILS_VERSION='~> 6.1.0'
+    - rvm: 2.5.8
+      env: RAILS_VERSION='~> 6.1.0'
+
+    # Rails 6 builds >= 2.4.10
     - rvm: 2.7.1
       env: RAILS_VERSION='~> 6.0.0'
     - rvm: 2.6.6
@@ -176,9 +184,6 @@ matrix:
       env: RAILS_VERSION='~> 3.0.20'
     - rvm: 1.8.7
       env: RAILS_VERSION='~> 3.0.20'
-
-  allow_failures:
-    - env: RAILS_VERSION='~> 6.0.0'
 
   fast_finish: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
   if File.exist?(library_path) && !ENV['USE_GIT_REPOS']
     gem lib, :path => library_path
   else
-    gem lib, :git => "git://github.com/rspec/#{lib}.git"
+    gem lib, :github => "rspec/#{lib}"
   end
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :documentation do
   gem 'github-markup', '1.0.0'
 end
 
-version = ENV.fetch('RAILS_VERSION', '6.0.0')
+version = ENV.fetch('RAILS_VERSION', '6.1.1')
 version_float = version.tr('-', '.').tr('~> ', '').to_f
 
 if version_float < 4

--- a/lib/rspec/active_model/mocks/mocks.rb
+++ b/lib/rspec/active_model/mocks/mocks.rb
@@ -243,11 +243,13 @@ EOM
     def stub_model(model_class, stubs={})
       model_class.new.tap do |m|
         m.extend ActiveModelStubExtensions
-        if defined?(ActiveRecord) && model_class < ActiveRecord::Base && model_class.primary_key
+        if defined?(ActiveRecord) && model_class < ActiveRecord::Base
           m.extend ActiveRecordStubExtensions
-          primary_key = model_class.primary_key.to_sym
-          stubs = {primary_key => next_id}.merge(stubs)
-          stubs = {:persisted? => !!stubs[primary_key]}.merge(stubs)
+          if model_class.primary_key
+            primary_key = model_class.primary_key.to_sym
+            stubs = {primary_key => next_id}.merge(stubs)
+            stubs = {:persisted? => !!stubs[primary_key]}.merge(stubs)
+          end
         else
           stubs = {:id => next_id}.merge(stubs)
           stubs = {:persisted? => !!stubs[:id]}.merge(stubs)

--- a/lib/rspec/active_model/mocks/mocks.rb
+++ b/lib/rspec/active_model/mocks/mocks.rb
@@ -159,6 +159,10 @@ EOM
           __model_class_has_column?(attr_name)
         end unless stubs.has_key?(:has_attribute?)
 
+        msingleton.__send__(:define_method, :_has_attribute?) do |attr_name|
+          __model_class_has_column?(attr_name)
+        end unless stubs.has_key?(:_has_attribute?)
+
         msingleton.__send__(:define_method, :respond_to?) do |method_name, *args|
         include_private = args.first || false
           __model_class_has_column?(method_name) ? true : super(method_name, include_private)

--- a/lib/rspec/active_model/mocks/mocks.rb
+++ b/lib/rspec/active_model/mocks/mocks.rb
@@ -163,6 +163,10 @@ EOM
           __model_class_has_column?(attr_name)
         end unless stubs.has_key?(:_has_attribute?)
 
+        msingleton.__send__(:define_method, :_write_attribute) do |_k, _v|
+          ;
+        end unless stubs.has_key?(:_write_attribute)
+
         msingleton.__send__(:define_method, :respond_to?) do |method_name, *args|
         include_private = args.first || false
           __model_class_has_column?(method_name) ? true : super(method_name, include_private)

--- a/spec/rspec/active_model/mocks/mock_model_spec.rb
+++ b/spec/rspec/active_model/mocks/mock_model_spec.rb
@@ -123,19 +123,19 @@ describe "mock_model(RealModel)" do
     end
   end
 
-  xdescribe "has_many association that doesn't exist yet" do
+  describe "has_one association" do
     before(:each) do
-      @real = HasManyAssociatedModel.create!
-      @mock_model = mock_model("Other")
-      @real.nonexistent_models = [@mock_model]
+      @real = HasOneAssociatedModel.new
+      @mock_model = mock_model(MockableModel)
+      @real.mockable_model = @mock_model
     end
 
     it "passes: associated_model == mock" do
-      expect([@mock_models]).to eq(@real.nonexistent_model)
+      expect(@mock_model).to eq(@real.mockable_model)
     end
 
     it "passes: mock == associated_model" do
-      expect(@real.nonexistent_model).to eq([@mock_models])
+      expect(@real.mockable_model).to eq(@mock_model)
     end
   end
 

--- a/spec/rspec/active_model/mocks/mock_model_spec.rb
+++ b/spec/rspec/active_model/mocks/mock_model_spec.rb
@@ -107,7 +107,39 @@ describe "mock_model(RealModel)" do
     end
   end
 
-  describe "as association" do
+  describe "has_many association" do
+    before(:each) do
+      @real = HasManyAssociatedModel.new
+      @mock_model = mock_model(MockableModel)
+      @real.mockable_models << @mock_model
+    end
+
+    it "passes: associated_model == mock" do
+      expect([@mock_model]).to eq(@real.mockable_models)
+    end
+
+    it "passes: mock == associated_model" do
+      expect(@real.mockable_models).to eq([@mock_model])
+    end
+  end
+
+  xdescribe "has_many association that doesn't exist yet" do
+    before(:each) do
+      @real = HasManyAssociatedModel.create!
+      @mock_model = mock_model("Other")
+      @real.nonexistent_models = [@mock_model]
+    end
+
+    it "passes: associated_model == mock" do
+      expect([@mock_models]).to eq(@real.nonexistent_model)
+    end
+
+    it "passes: mock == associated_model" do
+      expect(@real.nonexistent_model).to eq([@mock_models])
+    end
+  end
+
+  describe "belongs_to association" do
     before(:each) do
       @real = AssociatedModel.create!
       @mock_model = mock_model(MockableModel)
@@ -123,7 +155,7 @@ describe "mock_model(RealModel)" do
     end
   end
 
-  describe "as association that doesn't exist yet" do
+  describe "belongs_to association that doesn't exist yet" do
     before(:each) do
       @real = AssociatedModel.create!
       @mock_model = mock_model("Other")

--- a/spec/rspec/active_model/mocks/mock_model_spec.rb
+++ b/spec/rspec/active_model/mocks/mock_model_spec.rb
@@ -195,6 +195,13 @@ describe "mock_model(RealModel)" do
 
   describe "#has_attribute?" do
     context "with an ActiveRecord model" do
+      around do |example|
+        original = RSpec::Mocks.configuration.syntax
+        RSpec::Mocks.configuration.syntax = :should
+        example.run
+        RSpec::Mocks.configuration.syntax = original
+      end
+
       before(:each) do
         MockableModel.stub(:column_names).and_return(["column_a", "column_b"])
         @model = mock_model(MockableModel)

--- a/spec/support/ar_classes.rb
+++ b/spec/support/ar_classes.rb
@@ -58,6 +58,12 @@ class HasManyAssociatedModel < ActiveRecord::Base
   has_many :nonexistent_models, :class_name => "Other"
 end
 
+class HasOneAssociatedModel < ActiveRecord::Base
+  extend Connections
+  has_one :mockable_model
+  has_one :nonexistent_model, :class_name => "Other"
+end
+
 class AssociatedModel < ActiveRecord::Base
   extend Connections
   belongs_to :mockable_model

--- a/spec/support/ar_classes.rb
+++ b/spec/support/ar_classes.rb
@@ -10,7 +10,8 @@ module Connections
         #{host.primary_key} integer PRIMARY KEY AUTOINCREMENT,
         associated_model_id integer,
         mockable_model_id integer,
-        nonexistent_model_id integer
+        nonexistent_model_id integer,
+        has_many_associated_model_id integer
       )
     eosql
   end
@@ -49,6 +50,12 @@ class MockableModelNoPrimaryKey < ActiveRecord::Base
 end
 
 class SubMockableModel < MockableModel
+end
+
+class HasManyAssociatedModel < ActiveRecord::Base
+  extend Connections
+  has_many :mockable_models
+  has_many :nonexistent_models, :class_name => "Other"
 end
 
 class AssociatedModel < ActiveRecord::Base


### PR DESCRIPTION
This is a follow up to https://github.com/rspec/rspec-activemodel-mocks/pull/45 that gets some specific association cases working under Rails 6.1