### PR TITLE
Prefer File.exist? to avoid deprecation

### DIFF
--- a/rspec-activemodel-mocks.gemspec
+++ b/rspec-activemodel-mocks.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.require_path      = "lib"
 
   private_key = File.expand_path('~/.gem/rspec-gem-private_key.pem')
-  if File.exists?(private_key)
+  if File.exist?(private_key)
     s.signing_key = private_key
     s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end


### PR DESCRIPTION
This very small change avoids a deprecation warning in later Rubies.