### PR TITLE
Use GitHub Actions badge in README [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RSpec::ActiveModel::Mocks [![Build Status](https://secure.travis-ci.org/rspec/rspec-activemodel-mocks.svg?branch=main)](http://travis-ci.org/rspec/rspec-activemodel-mocks)
+# RSpec::ActiveModel::Mocks [![RSpec CI](https://github.com/rspec/rspec-activemodel-mocks/actions/workflows/ci.yml/badge.svg)](https://github.com/rspec/rspec-activemodel-mocks/actions/workflows/ci.yml)
 
 RSpec::ActiveModel::Mocks provides tools for testing `ActiveModel` classes.
 


### PR DESCRIPTION
This PR changes the badge in the README from Travis, to GitHub Actions.