### PR TITLE
Mock === on the modal_class when defining a mock

### DIFF
--- a/lib/rspec/active_model/mocks/mocks.rb
+++ b/lib/rspec/active_model/mocks/mocks.rb
@@ -124,6 +124,11 @@ EOM
                :blank? => false}.merge(stubs)
 
       double("#{model_class.name}_#{stubs[:id]}", stubs).tap do |m|
+        if model_class.method(:===).owner == Module && !stubs.has_key?(:===)
+          allow(model_class).to receive(:===).and_wrap_original do |original, other|
+            m === other || original.call(other)
+          end
+        end
         msingleton = class << m; self; end
         msingleton.class_eval do
           include ActiveModelInstanceMethods

--- a/spec/rspec/active_model/mocks/mock_model_spec.rb
+++ b/spec/rspec/active_model/mocks/mock_model_spec.rb
@@ -157,6 +157,50 @@ describe "mock_model(RealModel)" do
     end
   end
 
+  describe "#===" do
+    it "works with a case statement" do
+      case mock_model(MockableModel)
+      when MockableModel then true
+      else
+        raise
+      end
+
+      case :not_mockable_model
+      when MockableModel then raise
+      else
+        true
+      end
+    end
+
+    it "won't break previous stubs" do
+      allow(MockableModel).to receive(:===).with("string") { true }
+      mock_model(MockableModel)
+
+      case "string"
+      when MockableModel then true
+      else
+        raise
+      end
+    end
+
+    it "won't override class definitions" do
+      another_mockable_model =
+        Class.new(MockableModel) do
+          def self.===(other)
+            true
+          end
+        end
+
+      mock_model(another_mockable_model)
+
+      case "string"
+      when another_mockable_model then true
+      else
+        raise
+      end
+    end
+  end
+
   describe "#kind_of?" do
     before(:each) do
       @model = mock_model(SubMockableModel)

--- a/spec/rspec/active_model/mocks/stub_model_spec.rb
+++ b/spec/rspec/active_model/mocks/stub_model_spec.rb
@@ -161,6 +161,21 @@ describe "stub_model" do
       end
       expect(model).to be(@block_arg)
     end
+  end
 
+  describe "#===" do
+    it "works with a case statement" do
+      case stub_model(MockableModel)
+      when MockableModel then true
+      else
+        raise
+      end
+
+      case :not_stub_model
+      when MockableModel then raise
+      else
+        true
+      end
+    end
   end
 end


### PR DESCRIPTION
Rails 7.1 dropped a custom implementation of `.===` for models (in https://github.com/rails/rails/commit/31482d286790587a906c52ababf2e354fc2d460f) which allowed our mocks to pass the case equality check, this was a side effect of code they'd written for another means but we can restore the desired behaviour by mocking `===` on the class when defining a `mock_model`.

Fixes #54 