### PR TITLE
Fix === for multiple mocks of the same model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ### Development
 [Full Changelog](https://github.com/rspec/rspec-activemodel-mocks/compare/v1.2.0...main)
 
+Bug fixes:
+
+* Fix `===` to work with multiple mocks. (@bquorning, #61)
+
 ### 1.2.0 / 2023-12-10
 [Full Changelog](https://github.com/rspec/rspec-activemodel-mocks/compare/v1.1.0...v1.2.0)
 

--- a/spec/rspec/active_model/mocks/mock_model_spec.rb
+++ b/spec/rspec/active_model/mocks/mock_model_spec.rb
@@ -209,6 +209,19 @@ describe "mock_model(RealModel)" do
       end
       # rubocop:enable Lint/LiteralAsCondition
     end
+
+    it "works for multiple mocks of the same model" do
+      foo = mock_model(MockableModel)
+      bar = mock_model(MockableModel)
+      baz = mock_model(MockableModelNoPrimaryKey)
+      quz = mock_model(MockableModel)
+
+      expect(MockableModel === foo).to be(true)
+      expect(MockableModel === bar).to be(true)
+      expect(MockableModel === baz).to be(false)
+      expect(MockableModelNoPrimaryKey === baz).to be(true)
+      expect(MockableModel === quz).to be(true)
+    end
   end
 
   describe "#kind_of?" do

--- a/spec/rspec/active_model/mocks/stub_model_spec.rb
+++ b/spec/rspec/active_model/mocks/stub_model_spec.rb
@@ -181,5 +181,18 @@ describe "stub_model" do
       end
       # rubocop:enable Lint/LiteralAsCondition
     end
+
+    it "works for multiple mocks of the same model" do
+      foo = stub_model(MockableModel)
+      bar = stub_model(MockableModel)
+      baz = stub_model(MockableModelNoPrimaryKey)
+      qux = stub_model(MockableModel)
+
+      expect(MockableModel === foo).to be(true)
+      expect(MockableModel === bar).to be(true)
+      expect(MockableModel === baz).to be(false)
+      expect(MockableModelNoPrimaryKey === baz).to be(true)
+      expect(MockableModel === qux).to be(true)
+    end
   end
 end


### PR DESCRIPTION
When the same model is mocked more than once in the same context, comparing with the model class using `#===` would only return true for the first of the mocks. All following mocks would return false when compared to the original model class using `#===`.

For `#===` to work correctly, we register each mock in a "mock_store" on the `RSpec::ActiveModel::Mocks::Mocks` module. The store is implemented as an RSpec stub, so it is reset after each spec example.

Fixes #60

I realize that I’m adding some complex code into some already-complex code, so please let me know if you’d rather have it implemented in some other way.