### PR TITLE
Fix the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,7 @@ jobs:
               RAILS_VERSION: '~> 4.2.0'
 
     env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       LEGACY_CI: true
       JRUBY_OPTS: ${{ matrix.container.jruby_opts || '--dev' }}
       RAILS_VERSION: ${{ matrix.env.RAILS_VERSION }}

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,12 @@ gemspec
   if File.exist?(library_path) && !ENV['USE_GIT_REPOS']
     gem lib, :path => library_path
   else
-    gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch => ENV.fetch('RSPEC_BRANCH', 'main')
+    branch = ENV.fetch('RSPEC_BRANCH', 'main')
+    if lib == 'rspec'
+      gem 'rspec', :git => "https://github.com/rspec/rspec-metagem.git", :branch => branch
+    else
+      gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch => branch
+    end
   end
 end
 

--- a/rspec-activemodel-mocks.gemspec
+++ b/rspec-activemodel-mocks.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
     s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end
 
-  s.add_runtime_dependency('activemodel',   [">= 3.0"])
-  s.add_runtime_dependency('activesupport', [">= 3.0"])
-  s.add_runtime_dependency('rspec-mocks',   [">= 2.99", "< 4.0"])
+  s.add_dependency('activemodel',   [">= 3.0"])
+  s.add_dependency('activesupport', [">= 3.0"])
+  s.add_dependency('rspec-mocks',   [">= 2.99", "< 4.0"])
 end


### PR DESCRIPTION
On opening #61 I realized that [CI was failing for unrelated reasons](https://github.com/rspec/rspec-activemodel-mocks/actions/runs/11072345720), and found a few things to fix.

On the legacy builds, actions/checkout@v3 (and v4 too if you try) fail with

```
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.25' not found (required by /__e/node20/bin/node)
```

See also https://github.com/actions/checkout/issues/1590 (people reporting it broken with v3 since August 16th or so).