### PR TITLE
Add support for active record read_attribute public method

### DIFF
--- a/lib/rspec/active_model/mocks/mocks.rb
+++ b/lib/rspec/active_model/mocks/mocks.rb
@@ -106,6 +106,7 @@ module RSpec::ActiveModel::Mocks
           model_class = Object.const_set(string_or_model_class, Class.new do
             # rubocop:disable  Style/SingleLineMethods
             extend ::ActiveModel::Naming
+
             def self.primary_key; :id; end
 
             # For detection of being a valid association in 7+
@@ -149,6 +150,7 @@ It received #{model_class.inspect}
         msingleton = class << m; self; end
         msingleton.class_eval do
           include ActiveModelInstanceMethods
+
           include ActiveRecordInstanceMethods if defined?(ActiveRecord)
           include ActiveModel::Conversion
           include ActiveModel::Validations

--- a/lib/rspec/active_model/mocks/mocks.rb
+++ b/lib/rspec/active_model/mocks/mocks.rb
@@ -61,6 +61,9 @@ module RSpec::ActiveModel::Mocks
       # alternative to record['id']
       alias_method :_read_attribute, :[]
 
+      # Rails>7.1 added read_attribute for external usage similar to record['id']
+      alias_method :read_attribute, :[]
+
       # Returns the opposite of `persisted?`
       def new_record?
         !persisted?

--- a/spec/rspec/active_model/mocks/mock_model_spec.rb
+++ b/spec/rspec/active_model/mocks/mock_model_spec.rb
@@ -482,6 +482,44 @@ describe "mock_model(RealModel)" do
     end
   end
 
+  describe "attribute access methods" do
+    it "supports [] method with symbol" do
+      model = mock_model(MockableModel, :name => "John", :age => 25)
+      expect(model[:name]).to eq("John")
+      expect(model[:age]).to eq(25)
+    end
+
+    it "supports [] method with string" do
+      model = mock_model(MockableModel, :name => "John", :age => 25)
+      expect(model["name"]).to eq("John")
+      expect(model["age"]).to eq(25)
+    end
+
+    it "supports read_attribute method with symbol" do
+      model = mock_model(MockableModel, :name => "John", :age => 25)
+      expect(model.read_attribute(:name)).to eq("John")
+      expect(model.read_attribute(:age)).to eq(25)
+    end
+
+    it "supports read_attribute method with string" do
+      model = mock_model(MockableModel, :name => "John", :age => 25)
+      expect(model.read_attribute("name")).to eq("John")
+      expect(model.read_attribute("age")).to eq(25)
+    end
+
+    it "supports _read_attribute method with symbol" do
+      model = mock_model(MockableModel, :name => "John", :age => 25)
+      expect(model._read_attribute(:name)).to eq("John")
+      expect(model._read_attribute(:age)).to eq(25)
+    end
+
+    it "supports _read_attribute method with string" do
+      model = mock_model(MockableModel, :name => "John", :age => 25)
+      expect(model._read_attribute("name")).to eq("John")
+      expect(model._read_attribute("age")).to eq(25)
+    end
+  end
+
   describe "ActiveModel Lint tests" do
     # rubocop:disable Lint/EmptyExpression,Metrics/BlockNesting
     begin

--- a/spec/rspec/active_model/mocks/mock_model_spec.rb
+++ b/spec/rspec/active_model/mocks/mock_model_spec.rb
@@ -557,6 +557,7 @@ describe "mock_model(RealModel)" do
             ERR
           end
           include Test::Unit::Assertions
+
           if defined?((Test::Unit::AutoRunner.need_auto_run = ()))
             Test::Unit::AutoRunner.need_auto_run = false
           elsif defined?((Test::Unit.run = ()))
@@ -570,6 +571,7 @@ describe "mock_model(RealModel)" do
       else
         require 'test/unit/assertions'
         include Test::Unit::Assertions
+
         if defined?((Test::Unit::AutoRunner.need_auto_run = ()))
           Test::Unit::AutoRunner.need_auto_run = false
         elsif defined?((Test::Unit.run = ()))

--- a/spec/support/ar_classes.rb
+++ b/spec/support/ar_classes.rb
@@ -41,6 +41,7 @@ end
 
 class MockableModel < ActiveRecord::Base
   extend Connections
+
   has_one :associated_model
 end
 
@@ -54,6 +55,7 @@ end
 
 class AssociatedModel < ActiveRecord::Base
   extend Connections
+
   belongs_to :mockable_model
   belongs_to :nonexistent_model, :class_name => "Other"
 end
@@ -61,5 +63,6 @@ end
 class AlternatePrimaryKeyModel < ActiveRecord::Base
   self.primary_key = :my_id
   extend Connections
+
   attr_accessor :my_id
 end


### PR DESCRIPTION
## Add support for `read_attribute` method

### Changes
- Added `alias_method :read_attribute, :[]` to support Rails 7.1+ `read_attribute` method
- Added comprehensive tests for `read_attribute`, `_read_attribute`, and `[]` methods
- Tests verify functionality with both symbol and string keys

### Why
Rails 7.1+ introduced `read_attribute` as a [public method](https://apidock.com/rails/v7.1.3.2/ActiveRecord/AttributeMethods/Read/read_attribute) for external usage, similar to `record['id']`. This change ensures compatibility with newer Rails versions. 
It's called in other gems e.g Bullet version 8.0.8 uses this public method [here](https://github.com/flyerhzm/bullet/blob/main/lib/bullet/ext/object.rb#L29) which causes errors in specs like `RSpec::Mocks::MockExpectationError`
